### PR TITLE
Remove unsupported -Force when changing WerSvc startup type

### DIFF
--- a/RepairTweaks.ps1
+++ b/RepairTweaks.ps1
@@ -300,7 +300,7 @@ function repairTweaks($tweakNames) {
         }
         #repair windows error reporting
         if ($tweak -eq 'Windows Error Reporting') {
-            Set-Service -Name WerSvc -StartupType Manual -Force 
+            Set-Service -Name WerSvc -StartupType Manual 
             Remove-ItemProperty -Path 'registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting' -Name 'Disabled' -Force -ErrorAction SilentlyContinue
         }
         #repair csrss priority


### PR DESCRIPTION
When changing the startup type for WerSvc, the script uses -Force, which causes the command to fail.

-Force isn't needed here, it is only applicable when stopping a service, not when changing its startup type.