### PR TITLE
fix script exit method and add black ui

### DIFF
--- a/RepairTweaks.ps1
+++ b/RepairTweaks.ps1
@@ -1,8 +1,13 @@
 #repair bad tweaks by zoic
-If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
+if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
     Start-Process PowerShell.exe -ArgumentList ("-NoProfile -ExecutionPolicy Bypass -File `"{0}`"" -f $PSCommandPath) -Verb RunAs
-    Exit	
+    exit	
 }
+
+#black background with white text
+$Host.UI.RawUI.BackgroundColor = 'Black'
+$Host.UI.RawUI.ForegroundColor = 'White'
+Clear-Host
 
 #global vars
 $Global:currentControlSet = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet'
@@ -378,10 +383,9 @@ foreach ($tweak in $getTweaks.GetEnumerator()) {
 #no bad tweaks found
 if ($trueCount -eq $getTweaks.Count) {
     Write-Host 'No Bad Tweaks Found!'
-    $input = Read-Host 'Press ANY Key to Exit...'
-    if ($input) {
-        exit
-    }
+    Write-Host 'Press ANY Key to Exit...' -NoNewline
+    $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+    exit
 }
 else {
     #use choice cmdlet
@@ -403,10 +407,9 @@ else {
         }
         if ($trueCount -eq $getTweaks.Count) {
             Write-Host 'Tweaks Repaired Successfully!'
-            $input = Read-Host 'Press ANY Key to Exit...'
-            if ($input) {
-                exit
-            }
+            Write-Host 'Press ANY Key to Exit...' -NoNewline
+            $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+            exit
         }
         else {
             Write-Host 'Tweaks Not Repaired:'


### PR DESCRIPTION
`Read-Host` waits for a full line + enter so "Press ANY Key to Exit" wasnt accurate
now uses `RawUI.ReadKey()` so it exits on any single key press
also made the ui black

here is a quick before and after preview:


https://github.com/user-attachments/assets/949bb9b7-3b71-4826-8f89-93281889fd9d

