### PR TITLE
switch iwr to irm to prevent script execution warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As tweaking windows becomes more popular self proclaimed experts incorrectly int
 #### Option 1: 
 Run Script From Terminal or PowerShell Prompt as Admin
 ````
- iwr 'https://raw.githubusercontent.com/zoicware/RepairBadTweaks/main/RepairTweaks.ps1' | iex 
+ irm 'https://raw.githubusercontent.com/zoicware/RepairBadTweaks/main/RepairTweaks.ps1' | iex 
  ````
 
  #### Option 2:

--- a/RepairTweaks.ps1
+++ b/RepairTweaks.ps1
@@ -1,8 +1,13 @@
 #repair bad tweaks by zoic
-If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
+if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator')) {
     Start-Process PowerShell.exe -ArgumentList ("-NoProfile -ExecutionPolicy Bypass -File `"{0}`"" -f $PSCommandPath) -Verb RunAs
-    Exit	
+    exit	
 }
+
+#black background with white text
+$Host.UI.RawUI.BackgroundColor = 'Black'
+$Host.UI.RawUI.ForegroundColor = 'White'
+Clear-Host
 
 #global vars
 $Global:currentControlSet = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet'
@@ -378,10 +383,9 @@ foreach ($tweak in $getTweaks.GetEnumerator()) {
 #no bad tweaks found
 if ($trueCount -eq $getTweaks.Count) {
     Write-Host 'No Bad Tweaks Found!'
-    $input = Read-Host 'Press ANY Key to Exit...'
-    if ($input) {
-        exit
-    }
+    Write-Host 'Press ANY Key to Exit...' -NoNewline
+    $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+    exit
 }
 else {
     #use choice cmdlet
@@ -403,10 +407,9 @@ else {
         }
         if ($trueCount -eq $getTweaks.Count) {
             Write-Host 'Tweaks Repaired Successfully!'
-            $input = Read-Host 'Press ANY Key to Exit...'
-            if ($input) {
-                exit
-            }
+            Write-Host 'Press ANY Key to Exit...' -NoNewline
+            $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+            exit
         }
         else {
             Write-Host 'Tweaks Not Repaired:'


### PR DESCRIPTION
`Invoke-WebRequest` (iwr) parses response content as html by default which triggers a "Script Execution Risk" security prompt before running
switched to `Invoke-RestMethod` (irm) which just returns raw content and skips that warning entirely

<img width="992" height="1039" alt="Screenshot 2026-08-08 201225" src="https://github.com/user-attachments/assets/43f2a079-ad5f-4cdb-9c81-318b014d56b2" />
